### PR TITLE
Fix graphql explorer

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -250,3 +250,9 @@ html .table-of-contents ul {
 .pagination-nav {
   display: none;
 }
+
+/* For the Graphql Explorer Page */
+.graphql {
+  height: 100vh;
+  width: 100vw;
+}


### PR DESCRIPTION
This was unintentionally removed when cleaning up the css; its needed to ensure the height of the viewer can be seen