### PR TITLE
port contents from main readme

### DIFF
--- a/docs/docs/developers/getting-started/cli-auth.mdx
+++ b/docs/docs/developers/getting-started/cli-auth.mdx
@@ -25,7 +25,7 @@ The Openlane CLI authenticates for local development either with an API or perso
 The Openlane CLI is available for MacOS using `homebrew`.
 
 ```shell
-brew install theopenlane/tap/openlane
+brew install --cask theopenlane/tap/openlane
 ```
 
 

--- a/docs/docs/developers/getting-started/local-setup.mdx
+++ b/docs/docs/developers/getting-started/local-setup.mdx
@@ -46,7 +46,7 @@ task
 
 ## IDE Build Tags
 
-The core codebase uses [build tags](../schema-and-codegen/multi-module-structure.mdx#build-tags) for conditional compilation. Configure your IDE with the `cli,test,codegen` tags, or functions gated behind them will appear undefined and your language server will flag imports as unused.
+The core codebase uses [build tags](../schema-and-codegen/multi-module-structure.mdx#build-tags) for conditional compilation. Configure your IDE with the `cli,test,codegen,examples` tags, or functions gated behind them will appear undefined and your language server will flag imports as unused.
 
 <Tabs groupId="ide" queryString>
     <TabItem value="vscode" label="VSCode">
@@ -54,11 +54,11 @@ The core codebase uses [build tags](../schema-and-codegen/multi-module-structure
 
         ```json
         {
-          "go.buildTags": "cli,test,codegen"
+          "go.buildTags": "cli,test,codegen,examples"
         }
         ```
     </TabItem>
     <TabItem value="goland" label="GoLand">
-        Navigate to _Settings > Go > Build Tags_ and add `cli,test,codegen` as a comma-separated list.
+        Navigate to _Settings > Go > Build Tags_ and add `cli,test,codegen,examples` as a comma-separated list.
     </TabItem>
 </Tabs>

--- a/docs/docs/developers/getting-started/openlane-ui.mdx
+++ b/docs/docs/developers/getting-started/openlane-ui.mdx
@@ -1,0 +1,16 @@
+---
+title: Openlane UI
+description: Run the open-source web console against a local or self-hosted server
+sidebar_position: 5
+tags:
+    - local
+    - development
+---
+
+# Openlane UI
+
+The [Openlane UI](https://github.com/theopenlane/openlane-ui) is the open-source web console for Openlane. You can run it locally against a development server or host it on your own infrastructure; the repository README covers setup and configuration.
+
+:::note
+Not everything in the UI is configurable or removable yet, such as links to our Terms of Service and Privacy Policy or other branding and assets owned by theopenlane, Inc. Plan for this if you are self-hosting the console.
+:::

--- a/docs/docs/developers/getting-started/overview.mdx
+++ b/docs/docs/developers/getting-started/overview.mdx
@@ -15,6 +15,7 @@ Use this section to get a working local developer environment quickly.
 1. [Local Setup](./local-setup.mdx): install required tooling and configure your IDE
 1. [Run the Stack](./run-the-stack.mdx): start the server and dependencies locally
 1. [CLI Auth](./cli-auth.mdx): install and authenticate the Openlane CLI
+1. [Openlane UI](./openlane-ui.mdx): run the web console against your local server
 
 </Steps>
 

--- a/docs/docs/developers/getting-started/run-the-stack.mdx
+++ b/docs/docs/developers/getting-started/run-the-stack.mdx
@@ -92,4 +92,42 @@ Because the CSRF middleware stores the token only in the client’s cookie and n
 Therefore, rolling restarts on Kubernetes will not force new tokens to be issued and should not cause requests to fail, provided the client retains its CSRF cookie.
 :::
 
+### Querying the API with Apollo Sandbox
+
+We recommend the [Apollo sandbox](https://studio.apollographql.com/sandbox/explorer) for exploring the GraphQL API against a local server. Allow the sandbox origin in `config/.config.yaml`:
+
+```yaml
+server:
+  cors:
+    allowOrigins:
+      - https://studio.apollographql.com
+```
+
+In the Apollo connection settings, configure:
+
+1. Endpoint: `http://localhost:17608/query`
+1. Shared Headers: `Authorization` `Bearer tolp_REDACTED`
+
+Create an API token or personal access token against your local API with:
+
+```bash
+task cli:token:create
+```
+
+```bash
+task cli:pat:create
+```
+
+Both are also created automatically when you set up the test user with `task cli:user:all`. See [API Tokens & PATs](../security/api-tokens-and-pats.mdx) for how the two token types differ.
+
+### OpenFGA Playground
+
+Bring up a local OpenFGA environment with the compose setup in the core repository:
+
+```bash
+task docker:fga:up
+```
+
+This launches an interactive playground where you can inspect tuples and model changes to the [permission model](../security/privacy-and-authorization.mdx). If you hit a CORS and loopback error, see this [OpenFGA issue](https://github.com/openfga/openfga/issues/338#issuecomment-3511304207) for a workaround.
+
 

--- a/docs/docs/developers/operations/overview.mdx
+++ b/docs/docs/developers/operations/overview.mdx
@@ -10,3 +10,7 @@ Deployment and release operations for core and its infrastructure.
 
 * [Config and Secrets](./config-and-secrets.mdx): how configuration is structured and loaded, and how secrets flow from the secret manager into the running application
 * [Stripe Webhook Migration Runbook](./runbook-stripe-webhook-migration.mdx): rotating Stripe webhook API versions with no downtime
+
+## Deployment
+
+Running locally is the only supported deployment method today, but all required container images are published to the [GitHub container registry](https://github.com/orgs/theopenlane/packages?repo_name=core) for deployment into Kubernetes. [Config and Secrets](./config-and-secrets.mdx) covers how Helm values and external-secrets resources are generated from the config structs.

--- a/docs/docs/developers/schema-and-codegen/graphql-and-codegen.mdx
+++ b/docs/docs/developers/schema-and-codegen/graphql-and-codegen.mdx
@@ -30,6 +30,7 @@ task db:newschema -- MyNewSchema
 
 The file will be located in `internal/ent/schema/`, the file name matching the schema name. Work through the template:
 
+* Keep the `IDMixin` and the standard annotations included in the template; removing `IDMixin` causes ID type conflicts with the rest of the graph
 * Add [fields](https://entgo.io/docs/schema-fields) to the schema
 * Add [edges](https://entgo.io/docs/schema-edges) for 1:1, 1:m, or m:m relationships with other objects
 * Add [indexes](https://entgo.io/docs/schema-indexes) where needed

--- a/docs/docs/developers/schema-and-codegen/migrations-and-db.mdx
+++ b/docs/docs/developers/schema-and-codegen/migrations-and-db.mdx
@@ -36,7 +36,9 @@ Generate migrations after schema changes:
 task db:create
 ```
 
-This writes the atlas and goose migrations under [`db/`](https://github.com/theopenlane/core/tree/main/db) in core; see the [db README](https://github.com/theopenlane/core/blob/main/db/README.md) for tooling details and [MIGRATION.md](https://github.com/theopenlane/core/blob/main/db/MIGRATION.md) for the v2 permissions tuple migration.
+This writes the atlas migrations under [`db/migrations`](https://github.com/theopenlane/core/tree/main/db/migrations) and the goose migrations under [`db/migrations-goose-postgres`](https://github.com/theopenlane/core/tree/main/db/migrations-goose-postgres), one file for the base schema and one for the history schema. On every core pull request, the Atlas CI integration also comments with any issues it detects in the schema changes or migrations.
+
+See the [db README](https://github.com/theopenlane/core/blob/main/db/README.md) for tooling details and [MIGRATION.md](https://github.com/theopenlane/core/blob/main/db/MIGRATION.md) for the v2 permissions tuple migration.
 
 :::info
 For new schemas, follow the [codegen flow](./graphql-and-codegen.mdx) first, then generate migrations

--- a/docs/docs/developers/schema-and-codegen/multi-module-structure.mdx
+++ b/docs/docs/developers/schema-and-codegen/multi-module-structure.mdx
@@ -84,13 +84,14 @@ The codebase uses `//go:build` tags for conditional compilation. This keeps the 
 | `test` | Test-only code (test utilities, fixtures, mock implementations) | `internal/testutils/`, test files |
 | `cli` | CLI-specific code | `cli/`, CLI command implementations |
 | `codegen` | Code generation scripts (not compiled into any binary) | `internal/ent/generate/`, `internal/graphapi/generate/` |
+| `examples` | Example programs and development CLIs | `internal/workflows/examples/`, `internal/integrations/cli/` |
 | `clistripe` | Stripe webhook management CLI tool | `cmd/stripe-webhook/` |
 | `climanagedgroups` | Managed groups CLI tool | `cmd/managedgroups/` |
 | `ignore` | Generation scripts that should never be compiled | Various `generate.go` files |
 
 ### Impact on Development
 
-Your IDE needs to know about these tags to resolve symbols correctly. Without `cli,test,codegen` in your build tags, functions gated behind those tags will appear undefined. See [Local Setup](../getting-started/local-setup.mdx#ide-build-tags) for VSCode and GoLand configuration.
+Your IDE needs to know about these tags to resolve symbols correctly. Without `cli,test,codegen,examples` in your build tags, functions gated behind those tags will appear undefined. See [Local Setup](../getting-started/local-setup.mdx#ide-build-tags) for VSCode and GoLand configuration.
 
 On the command line, pass tags explicitly:
 

--- a/docs/docs/developers/security/privacy-and-authorization.mdx
+++ b/docs/docs/developers/security/privacy-and-authorization.mdx
@@ -224,5 +224,5 @@ When a request returns "not found" or "permission denied" on a record you know e
 - **Check the permission cache**: a recently-revoked permission may still be cached
 
 :::tip
-For local development, you can inspect FGA tuples directly using the OpenFGA CLI or the built-in FGA playground. The FGA module is defined in `fga/model/fga.mod` in the core repository with corresponding model directories.
+For local development, you can inspect FGA tuples directly using the OpenFGA CLI or the built-in FGA playground, started with `task docker:fga:up`; see [Run the Stack](../getting-started/run-the-stack.mdx#openfga-playground). The FGA module is defined in `fga/model/fga.mod` in the core repository with corresponding model directories.
 :::


### PR DESCRIPTION
Ports into product docs contents from the README in core in anticipation of re-writing that content